### PR TITLE
added a "friendly error message" in place of a "numpy error message"

### DIFF
--- a/directdemod/decode_noaa.py
+++ b/directdemod/decode_noaa.py
@@ -792,16 +792,21 @@ class decode_noaa:
 
             # determine if some data was found or not
             syncAdiff = np.abs(np.diff(self.__syncA) - (self.__syncCrudeSampRate*0.5))
-            minSyncAdiff = np.min([np.max(syncAdiff[i:i+constants.NOAA_DETECTCONSSYNCSNUM]) for i in range(len(syncAdiff)-constants.NOAA_DETECTCONSSYNCSNUM+1)])
+            syncAdiffTemp = np.array([np.max(syncAdiff[i:i+constants.NOAA_DETECTCONSSYNCSNUM]) for i in range(len(syncAdiff)-constants.NOAA_DETECTCONSSYNCSNUM+1)]) 
 
             syncBdiff = np.abs(np.diff(self.__syncB) - (self.__syncCrudeSampRate*0.5))
-            minSyncBdiff = np.min([np.max(syncBdiff[i:i+constants.NOAA_DETECTCONSSYNCSNUM]) for i in range(len(syncBdiff)-constants.NOAA_DETECTCONSSYNCSNUM+1)])
+            syncBdiffTemp = np.array([np.max(syncBdiff[i:i+constants.NOAA_DETECTCONSSYNCSNUM]) for i in range(len(syncBdiff)-constants.NOAA_DETECTCONSSYNCSNUM+1)])
 
-            if minSyncAdiff < constants.NOAA_DETECTMAXCHANGE or minSyncBdiff < constants.NOAA_DETECTMAXCHANGE:
-                logging.info('NOAA Signal was found')
-                self.__useful = 1
+            if syncAdiffTemp.size != 0 and syncBdiffTemp.size != 0:
+                minSyncAdiff = np.min(syncAdiffTemp)
+                minSyncBdiff = np.min(syncBdiffTemp)                
+                if minSyncAdiff < constants.NOAA_DETECTMAXCHANGE or minSyncBdiff < constants.NOAA_DETECTMAXCHANGE:
+                    logging.info('NOAA Signal was found')
+                    self.__useful = 1
+                else:
+                    logging.info('NOAA Signal was not found')
             else:
-                logging.info('NOAA Signal was not found')
+                pass
 
         return [self.__syncA, self.__syncB]
 

--- a/main.py
+++ b/main.py
@@ -271,7 +271,7 @@ for fileIndex in range(len(freqs)):
                 entryDict['filesCreated'].append(csvFileName)
 
             if noaaObj.useful == 0:
-                logging.info('No NOAA data was found at this frequency')
+                logging.error('No NOAA data was found at this frequency')
 
             entryDict['usefulness'] = noaaObj.useful
             entryDict['syncDetect'] = calculateSync


### PR DESCRIPTION
To solve #32, I suggest doing so:
+The numpy error generating part in `decode_noaa.py` is handeled using a try-catch bock, without taking care of error generated.
+If the ndarray would be empty, then `noaaObject.useful` should return `false`, thus automatically generating the required 'friendly error'.